### PR TITLE
Enable GCP Cloud Functions deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,19 @@ You can deploy this app to any Node.js hosting platform like:
 - Vercel
 - AWS Lambda
 - Google Cloud Run
+- Google Cloud Functions
 
 Make sure to set the environment variables in your hosting platform's configuration.
+
+### Google Cloud Functions
+
+1. Deploy using [`function.js`](function.js) as the entry point:
+   ```bash
+   gcloud functions deploy probotApp \
+     --runtime=nodejs18 --trigger-http --entry-point=probotApp
+   ```
+2. Set all required environment variables in the function configuration.
+
 
 ## License
 

--- a/function.js
+++ b/function.js
@@ -1,0 +1,10 @@
+const { createNodeMiddleware } = require('@octokit/webhooks');
+const { createProbotApp } = require('./index');
+
+// Create the Probot instance with all event handlers
+const probotApp = createProbotApp();
+
+// Reuse the middleware to handle HTTP requests in Google Cloud Functions
+const middleware = createNodeMiddleware(probotApp.webhooks, { path: '/' });
+
+exports.probotApp = (req, res) => middleware(req, res);


### PR DESCRIPTION
## Summary
- add `function.js` handler for Google Cloud Functions
- document Cloud Functions deployment steps in `README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ad2403b38832cb1ed9fd03c3a4816