### PR TITLE
Fix Cloud Run startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A GitHub App that uses Google's Vertex AI with Gemini to provide intelligent cod
      - Contents: Read-only
    - Under "Subscribe to events", select:
      - Pull request
+     - Issue comment
      - Installation
    - Click "Create GitHub App"
    - Generate a private key and download it
@@ -48,6 +49,7 @@ A GitHub App that uses Google's Vertex AI with Gemini to provide intelligent cod
    ```bash
    npm start
    ```
+   This command now runs `node index.js` under the hood.
 
    For development with auto-reload:
    ```bash
@@ -68,6 +70,11 @@ You can deploy this app to any Node.js hosting platform like:
 - AWS Lambda
 - Google Cloud Run
 - Google Cloud Functions
+
+### Google Cloud Run
+
+1. Build and deploy your container image as you normally would.
+2. Ensure the container executes `npm start` (which runs `node index.js`).
 
 Make sure to set the environment variables in your hosting platform's configuration.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A GitHub App that automatically reviews pull requests",
   "main": "index.js",
   "scripts": {
-    "start": "probot run ./index.js",
+    "start": "node index.js",
     "dev": "nodemon --exec \"npm start\"",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- restructure index.js event handlers
- export new registerEventHandlers helper
- start app using `run()` when run directly
- update start script to `node index.js`
- document new run command and add Cloud Run instructions
- include `Issue comment` webhook in setup docs
- handle GitHub raw and base64 content in `getFileContent`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684aded8dc94832c9bc8a2ae798b5eab