### PR TITLE
Finalize service documentation and engines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYour private key here\n-----END RS
 GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=your-region  # e.g., us-central1
 GOOGLE_APPLICATION_CREDENTIALS=path/to/your/service-account-key.json
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI-Powered GitHub PR Reviewer
 
-A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelligent code reviews for pull requests.
+A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelligent code reviews for pull requests. Requires **Node.js 18+**.
 
 ## Features
 
@@ -40,6 +40,7 @@ A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelli
    - Fill in the values from your GitHub App settings
    - For the private key, copy the contents of the downloaded `.pem` file and format it as a single line with `\n` for newlines
    - (Optional) Set `GENAI_MODEL` to override the default Gemini model
+   - (Optional) Set `PORT` for local testing (default `3000`)
    - (Optional) Tune limits with:
      - `MAX_FILES_TO_PROCESS` (default 20)
      - `MAX_DIFF_LENGTH`, `MAX_DIFF_LINES`, `MAX_FILE_SIZE`, and
@@ -54,7 +55,6 @@ A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelli
    ```bash
    npm start
    ```
-   This command now runs `node index.js` under the hood.
 
    For development with auto-reload:
    ```bash

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "probot": "^12.2.8"
   },
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0"
+    "node": ">= 18.0.0",
+    "npm": ">= 8.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary
- require Node 18+ in `package.json`
- document Node version and optional PORT variable in README
- add PORT to `.env.example`

## Testing
- `npm test -- --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_684c053072dc832c883609a720bd81fb