### PR TITLE
Externalize AI prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelli
 - **Supports Multiple Languages**: Works with various programming languages
 - **Focused Feedback**: Only reports issues with high confidence
 
+## Review Workflow
+
+All prompts used for AI analysis live under the `prompts/` directory. The app loads these templates at runtime and fills in variables such as the file name or manager instructions before sending them to Gemini. Editing the text files allows you to tweak the review style without changing code.
+
 ## Setup
 
 1. **Create a GitHub App**

--- a/prompts/final_review.md
+++ b/prompts/final_review.md
@@ -1,0 +1,3 @@
+# Final Review
+
+Combine related comments from the reviewer, remove duplicates, and fix any issues in the feedback.

--- a/prompts/final_review.md
+++ b/prompts/final_review.md
@@ -1,3 +1,6 @@
 # Final Review
 
-Combine related comments from the reviewer, remove duplicates, and fix any issues in the feedback.
+Please perform the following actions on the provided reviewer comments:
+* Combine related comments.
+* Remove duplicate comments.
+* Refine the feedback for clarity, conciseness, formatting and correctness.

--- a/prompts/line_review.md
+++ b/prompts/line_review.md
@@ -1,0 +1,11 @@
+# Line Review
+
+Using the manager instructions below, provide feedback for the change around line {{line}} in {{fileName}}.
+If there are no actionable suggestions return an empty response.
+
+## Manager Instructions
+{{managerPlan}}
+
+```
+{{snippet}}
+```

--- a/prompts/manager_summary.md
+++ b/prompts/manager_summary.md
@@ -1,0 +1,3 @@
+# Manager Summary
+
+Summarize the changes in this pull request and provide brief instructions for the reviewer. The manager does not need to perform a detailed review.

--- a/prompts/merge_line_comments.md
+++ b/prompts/merge_line_comments.md
@@ -1,6 +1,5 @@
 # Merge Line Comments
-
-Given multiple line review comments for {{fileName}}, merge comments that express similar feedback. For each merged comment output in the following format:
+Given multiple line review comments for {{fileName}}, each associated with one or more lines of code, merge comments that express similar feedback. For each merged comment output in the following format:
 
 LINES: comma-separated line numbers
 COMMENT: the merged comment text (may span multiple lines)

--- a/prompts/merge_line_comments.md
+++ b/prompts/merge_line_comments.md
@@ -1,0 +1,9 @@
+# Merge Line Comments
+
+Given multiple line review comments for {{fileName}}, merge comments that express similar feedback. For each merged comment output in the following format:
+
+LINES: comma-separated line numbers
+COMMENT: the merged comment text (may span multiple lines)
+END_COMMENT
+
+Repeat this block for each merged comment and do not include any other text.

--- a/prompts/merge_line_comments.md
+++ b/prompts/merge_line_comments.md
@@ -1,5 +1,5 @@
 # Merge Line Comments
-Given multiple line review comments for {{fileName}}, each associated with one or more lines of code, merge comments that express similar feedback. For each merged comment output in the following format:
+Given multiple review comments for {{fileName}}, where each comment is associated with one or more lines of code, merge comments that express similar feedback. For each merged comment output in the following format:
 
 LINES: comma-separated line numbers
 COMMENT: the merged comment text (may span multiple lines)

--- a/prompts/pr_summary_request.md
+++ b/prompts/pr_summary_request.md
@@ -1,0 +1,11 @@
+# PR Summary Request
+
+## PR Details
+- Title: {{prTitle}}
+- Author: {{prAuthor}}
+- Changed Files: {{changedFiles}}
+
+## Instructions
+Please provide a concise summary of the changes in this pull request.
+Focus on the main purpose and key changes. Be brief and to the point.
+Highlight any major architectural changes or potential impacts.

--- a/prompts/reviewer_task.md
+++ b/prompts/reviewer_task.md
@@ -1,0 +1,6 @@
+# Reviewer Task
+
+Follow the manager instructions below to review {{fileName}}. Focus on the blocks highlighted.
+
+## Manager Instructions
+{{managerPlan}}

--- a/prompts/reviewer_task.md
+++ b/prompts/reviewer_task.md
@@ -1,6 +1,5 @@
 # Reviewer Task
-
-Follow the manager instructions below to review {{fileName}}. Focus on the blocks highlighted.
+Follow the manager instructions below to review {{fileName}}. Focus on the code blocks highlighted.
 
 ## Manager Instructions
 {{managerPlan}}


### PR DESCRIPTION
## Summary
- move prompt templates to `prompts/`
- load prompt text from files at runtime
- document review workflow and editable prompts

## Testing
- `npm test`

------