### PR TITLE
Add repo specific instructions support

### DIFF
--- a/AI_REVIEW_INSTRUCTIONS_TEMPLATE.md
+++ b/AI_REVIEW_INSTRUCTIONS_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Custom AI Review Instructions Template
+
+Create a copy of this file named `AI_REVIEW_INSTRUCTIONS.md` in your repository's root or within any folder to provide additional guidance to the automated reviewer.
+
+Recommended sections:
+
+- **Purpose** - Briefly describe the goal of the repository or folder.
+- **Code Style** - Bullet points summarizing style or lint rules.
+- **Testing Requirements** - Outline required tests or commands to run.
+- **Documentation** - Notes about updating docs when code changes.
+- **Cross Repository Tasks** - Reminders to sync changes to other repos or packages.
+
+Edit or remove sections as needed. The contents will be included in the review prompts for files within the same directory hierarchy.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A GitHub App that uses Google's GenAI (Vertex AI) with Gemini to provide intelli
 
 All prompts used for AI analysis live under the `prompts/` directory. The app loads these templates at runtime and fills in variables such as the file name or manager instructions before sending them to Gemini. Editing the text files allows you to tweak the review style without changing code.
 
+To customise the review behaviour for a repository, add a file named `AI_REVIEW_INSTRUCTIONS.md` to the repository root or within any folder. The contents of the closest instructions file are inserted into the review prompts for files in that directory. See `AI_REVIEW_INSTRUCTIONS_TEMPLATE.md` for an example template.
+
 ## Setup
 
 1. **Create a GitHub App**

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -7,6 +7,7 @@ process.env.WEBHOOK_SECRET = 'test-secret';
 process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
 process.env.GOOGLE_CLOUD_LOCATION = 'us-central1';
 process.env.GOOGLE_APPLICATION_CREDENTIALS = 'test-credentials.json';
+process.env.ENABLE_REPO_INSTRUCTIONS = 'false';
 
 // Mock console methods to keep test output clean
 console.log = jest.fn();

--- a/prompts/line_review.md
+++ b/prompts/line_review.md
@@ -1,10 +1,13 @@
 # Line Review
 
-Using the manager instructions below, provide feedback for the change around line {{line}} in {{fileName}}.
+Using the manager instructions and any repository instructions below, provide feedback for the change around line {{line}} in {{fileName}}.
 If there are no actionable suggestions return an empty response.
 
 ## Manager Instructions
 {{managerPlan}}
+
+## Repository Instructions
+{{repoInstructions}}
 
 ```
 {{snippet}}

--- a/prompts/reviewer_task.md
+++ b/prompts/reviewer_task.md
@@ -1,5 +1,8 @@
 # Reviewer Task
-Follow the manager instructions below to review {{fileName}}. Focus on the code blocks highlighted.
+Follow the manager instructions and any repository instructions below to review {{fileName}}. Focus on the code blocks highlighted.
 
 ## Manager Instructions
 {{managerPlan}}
+
+## Repository Instructions
+{{repoInstructions}}


### PR DESCRIPTION
## Summary
- allow repository-level instructions in `AI_REVIEW_INSTRUCTIONS.md`
- load the closest instruction file for each reviewed file
- include repo instructions in reviewer and line prompts
- document instructions template and feature
- disable repo instructions in tests

## Testing
- `npm test`

------