### PR TITLE
Improve LLM provider setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYour private key here\n-----END RS
 GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=your-region  # e.g., us-central1
 GOOGLE_APPLICATION_CREDENTIALS=path/to/your/service-account-key.json
+OPENAI_API_KEY=your-openai-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key
+LLM_MAX_TOKENS=1024
+LLM_TEMPERATURE=0.2
+LLM_TOP_P=0.8
+LLM_TOP_K=40
 PORT=3000
 # Optional: override the label name that triggers a review
 TRIGGER_LABEL=ai-review

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ To customise the review behaviour for a repository, add a file named `AI_REVIEW_
    - For the private key, copy the contents of the downloaded `.pem` file and format it as a single line with `\n` for newlines
    - (Optional) Choose an AI provider with `LLM_PROVIDER` (`google`, `openai`, `anthropic`)
    - (Optional) Set `GENAI_MODEL`, `OPENAI_MODEL`, or `ANTHROPIC_MODEL` to override defaults
-   - (Optional) Provide provider API keys with `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`
-   - (Optional) Set `PORT` for local testing (default `3000`)
+  - Provide API keys with `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` when using the
+    corresponding provider
+  - (Optional) Configure generation with `LLM_MAX_TOKENS`, `LLM_TEMPERATURE`,
+    `LLM_TOP_P`, and `LLM_TOP_K`
+  - (Optional) Set `PORT` for local testing (default `3000`)
    - (Optional) Tune limits with:
      - `MAX_FILES_TO_PROCESS` (default 20)
      - `MAX_DIFF_LENGTH`, `MAX_DIFF_LINES`, `MAX_FILE_SIZE`, and

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -7,6 +7,12 @@ process.env.WEBHOOK_SECRET = 'test-secret';
 process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
 process.env.GOOGLE_CLOUD_LOCATION = 'us-central1';
 process.env.GOOGLE_APPLICATION_CREDENTIALS = 'test-credentials.json';
+process.env.OPENAI_API_KEY = 'openai-key';
+process.env.ANTHROPIC_API_KEY = 'anthropic-key';
+process.env.LLM_MAX_TOKENS = '1024';
+process.env.LLM_TEMPERATURE = '0.2';
+process.env.LLM_TOP_P = '0.8';
+process.env.LLM_TOP_K = '40';
 process.env.ENABLE_REPO_INSTRUCTIONS = 'false';
 
 // Mock console methods to keep test output clean

--- a/llm.js
+++ b/llm.js
@@ -1,5 +1,5 @@
-const { GoogleGenAI } = require('@google/genai');
-let OpenAI, Anthropic;
+let GoogleGenAI, OpenAI, Anthropic;
+try { GoogleGenAI = require('@google/genai').GoogleGenAI; } catch (e) { GoogleGenAI = null; }
 try { OpenAI = require('openai').OpenAI; } catch (e) { OpenAI = null; }
 try { Anthropic = require('@anthropic-ai/sdk').Anthropic; } catch (e) { Anthropic = null; }
 
@@ -7,39 +7,72 @@ function createClient() {
   const provider = (process.env.LLM_PROVIDER || 'google').toLowerCase();
   if (provider === 'openai') {
     if (!OpenAI) throw new Error('OpenAI library not installed');
-    const apiKey = process.env.OPENAI_API_KEY || 'test-key';
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('Missing OPENAI_API_KEY environment variable');
+    }
+    const apiKey = process.env.OPENAI_API_KEY;
     const client = new OpenAI({ apiKey });
     return {
       provider: 'openai',
       async generate(prompt, options = {}) {
         const model = options.model || process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
-        const res = await client.chat.completions.create({ model, messages: [{ role: 'user', content: prompt }] });
+        const maxTokens = parseInt(options.maxTokens || process.env.LLM_MAX_TOKENS || '1024', 10);
+        const temperature = parseFloat(options.temperature || process.env.LLM_TEMPERATURE || '1');
+        const topP = parseFloat(options.topP || process.env.LLM_TOP_P || '1');
+        const res = await client.chat.completions.create({
+          model,
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: maxTokens,
+          temperature,
+          top_p: topP
+        });
         return res.choices[0].message.content.trim();
       }
     };
   }
   if (provider === 'anthropic') {
     if (!Anthropic) throw new Error('Anthropic library not installed');
-    const apiKey = process.env.ANTHROPIC_API_KEY || 'test-key';
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error('Missing ANTHROPIC_API_KEY environment variable');
+    }
+    const apiKey = process.env.ANTHROPIC_API_KEY;
     const client = new Anthropic({ apiKey });
     return {
       provider: 'anthropic',
       async generate(prompt, options = {}) {
         const model = options.model || process.env.ANTHROPIC_MODEL || 'claude-3-sonnet-20240229';
-        const resp = await client.messages.create({ model, max_tokens: 1024, messages: [{ role: 'user', content: prompt }] });
+        const maxTokens = parseInt(options.maxTokens || process.env.LLM_MAX_TOKENS || '1024', 10);
+        const temperature = parseFloat(options.temperature || process.env.LLM_TEMPERATURE || '1');
+        const topP = parseFloat(options.topP || process.env.LLM_TOP_P || '1');
+        const resp = await client.messages.create({
+          model,
+          max_tokens: maxTokens,
+          temperature,
+          top_p: topP,
+          messages: [{ role: 'user', content: prompt }]
+        });
         return resp.content[0].text.trim();
       }
     };
   }
   // default google
+  if (!GoogleGenAI) throw new Error('GoogleGenAI library not installed');
   const project = process.env.GOOGLE_CLOUD_PROJECT;
   const location = process.env.GOOGLE_CLOUD_LOCATION;
+  if (!project || !location) {
+    throw new Error('Missing GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_LOCATION');
+  }
   const genAI = new GoogleGenAI({ vertexai: true, project, location });
   return {
     provider: 'google',
     async generate(prompt, options = {}) {
       const model = options.model || process.env.GENAI_MODEL || 'gemini-2.5-flash-preview-05-20';
-      const generationConfig = { maxOutputTokens: 4096, temperature: 0.2, topP: 0.8, topK: 40 };
+      const generationConfig = {
+        maxOutputTokens: parseInt(options.maxOutputTokens || process.env.LLM_MAX_TOKENS || '4096', 10),
+        temperature: parseFloat(options.temperature || process.env.LLM_TEMPERATURE || '0.2'),
+        topP: parseFloat(options.topP || process.env.LLM_TOP_P || '0.8'),
+        topK: parseInt(options.topK || process.env.LLM_TOP_K || '40', 10)
+      };
       const result = await genAI.models.generateContent({ model, contents: [{ role: 'user', parts: [{ text: prompt }] }], config: generationConfig });
       return result.text;
     }


### PR DESCRIPTION
## Summary
- validate API keys for OpenAI and Anthropic and remove fallback `test-key`
- guard Google GenAI import and constructor
- allow token configuration via env vars
- document required keys and update example env file
- update tests for new env vars
- use shared env vars for generation parameters

## Testing
- `npm test`
