### PR TITLE
Fix package.json diff handling

### DIFF
--- a/__tests__/summarizePackageJsonChanges.test.js
+++ b/__tests__/summarizePackageJsonChanges.test.js
@@ -1,0 +1,20 @@
+const { summarizePackageJsonChanges } = require('../index');
+
+describe('summarizePackageJsonChanges', () => {
+  it('reports added, removed and updated packages', () => {
+    const base = JSON.stringify({
+      dependencies: { a: '1.0.0', b: '1.0.0' },
+      devDependencies: { jest: '1.0.0' }
+    });
+    const head = JSON.stringify({
+      dependencies: { b: '1.1.0', c: '1.0.0' },
+      devDependencies: { jest: '1.0.0', eslint: '2.0.0' }
+    });
+
+    const summary = summarizePackageJsonChanges(base, head);
+    expect(summary).toContain('Added dependencies: c@1.0.0');
+    expect(summary).toContain('Removed dependencies: a@1.0.0');
+    expect(summary).toContain('Updated dependencies: b (1.0.0 -> 1.1.0)');
+    expect(summary).toContain('Added devDependencies: eslint@2.0.0');
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to summarize package.json dependency changes
- include dependency summary when processing package.json files
- export the new helper and test it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f710db2ac832cb177d5a2f3bb1c95