### PR TITLE
Improve repo instruction tests

### DIFF
--- a/__tests__/getRepoInstructions.test.js
+++ b/__tests__/getRepoInstructions.test.js
@@ -18,23 +18,21 @@ describe('getRepoInstructions', () => {
   afterEach(() => {
     nock.cleanAll();
     nock.enableNetConnect();
-    process.env.ENABLE_REPO_INSTRUCTIONS = 'false';
   });
 
   it('combines repo and folder instructions', async () => {
     nock('https://api.github.com')
       .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('AI_REVIEW_INSTRUCTIONS.md')}`)
       .query(q => q.ref === ref)
-      .reply(200, { content: Buffer.from('root instructions').toString('base64'), size: 10 });
+      .reply(200, { content: Buffer.from('root instructions').toString('base64'), size: 17 });
 
     nock('https://api.github.com')
       .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('folder/AI_REVIEW_INSTRUCTIONS.md')}`)
       .query(q => q.ref === ref)
-      .reply(200, { content: Buffer.from('folder instructions').toString('base64'), size: 10 });
+      .reply(200, { content: Buffer.from('folder instructions').toString('base64'), size: 19 });
 
     const result = await getRepoInstructions(octokit, mockOwner, mockRepo, 'folder/file.js', ref);
-    expect(result).toContain('folder instructions');
-    expect(result).toContain('root instructions');
+    expect(result).toMatch(/folder instructions[\s\S]*root instructions/);
   });
 
   it('returns repo instructions when only repo level exists', async () => {
@@ -50,5 +48,59 @@ describe('getRepoInstructions', () => {
 
     const result = await getRepoInstructions(octokit, mockOwner, mockRepo, 'folder/file.js', ref);
     expect(result).toBe('root only');
+  });
+
+  it('returns folder instructions when only folder level exists', async () => {
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(404);
+
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('folder/AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(200, { content: Buffer.from('folder only').toString('base64'), size: 11 });
+
+    const result = await getRepoInstructions(octokit, mockOwner, mockRepo, 'folder/file.js', ref);
+    expect(result).toBe('folder only');
+  });
+
+  it('returns empty string when no instructions found', async () => {
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(404);
+
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('folder/AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(404);
+
+    const result = await getRepoInstructions(octokit, mockOwner, mockRepo, 'folder/file.js', ref);
+    expect(result).toBe('');
+  });
+
+  it('handles nested folder paths', async () => {
+    const nestedPath = 'deeply/nested/folder/file.js';
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(200, { content: Buffer.from('root instructions').toString('base64'), size: 17 });
+
+    nock('https://api.github.com')
+      .get(`/repos/${mockOwner}/${mockRepo}/contents/${encodeURIComponent('deeply/nested/folder/AI_REVIEW_INSTRUCTIONS.md')}`)
+      .query(q => q.ref === ref)
+      .reply(200, { content: Buffer.from('folder instructions').toString('base64'), size: 19 });
+
+    const result = await getRepoInstructions(octokit, mockOwner, mockRepo, nestedPath, ref);
+    expect(result).toMatch(/folder instructions[\s\S]*root instructions/);
+  });
+
+  it('returns empty when ENABLE_REPO_INSTRUCTIONS is disabled', async () => {
+    process.env.ENABLE_REPO_INSTRUCTIONS = 'false';
+    jest.resetModules();
+    ({ getRepoInstructions } = require('../index'));
+    const result = await getRepoInstructions(octokit, mockOwner, mockRepo, 'folder/file.js', ref);
+    expect(result).toBe('');
   });
 });

--- a/index.js
+++ b/index.js
@@ -279,10 +279,10 @@ async function getRepoInstructions(octokit, owner, repo, filePath, ref) {
   // Then look for the closest folder-level instructions (excluding repo root)
   let folderLevel = '';
   const parts = path.posix.dirname(filePath).split('/');
-  for (let i = parts.length; i > 0; i--) {
+  for (let i = parts.length; i >= 0; i--) {
     const dir = parts.slice(0, i).join('/');
     const searchPath = path.posix.join(dir, INSTRUCTION_FILENAME);
-    if (searchPath === INSTRUCTION_FILENAME) continue; // skip repo root handled above
+    if (searchPath === INSTRUCTION_FILENAME || dir === '' || dir === '.') continue; // skip repo root handled above
     try {
       const content = await getFileContent(octokit, owner, repo, searchPath, ref);
       if (content && !content.startsWith('[File not found')) { folderLevel = content; break; }


### PR DESCRIPTION
## Summary
- add edge case coverage for `getRepoInstructions`
- update instruction combination test to check order
- allow repo and folder lookup loop to consider root dir again

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685fb99e6b94832ca0dea8df06fed1d4