### PR TITLE
Add /review replies for comment threads

### DIFF
--- a/__tests__/commandHandlers.test.js
+++ b/__tests__/commandHandlers.test.js
@@ -6,7 +6,8 @@ const {
   processReviewCommand,
   processWhatCommand,
   processFileDiff,
-  analyzeWithAI
+  analyzeWithAI,
+  processReviewCommentReply
 } = appModule;
 
 // privateKey is now solely set in __tests__/setup.js via process.env.PRIVATE_KEY
@@ -500,6 +501,124 @@ describe('Command Handlers', () => {
         expect.objectContaining({ id: 5 }),
         'please'
       );
+    });
+
+    it('handles /review with no extra text', async () => {
+      const payload = JSON.parse(JSON.stringify(reviewCommentPayload));
+      payload.comment.body = '/review';
+      payload.comment.id = 321;
+
+      const tokenNock = nock('https://api.github.com')
+        .post('/app/installations/2/access_tokens')
+        .reply(200, { token: 'test-token' });
+
+      const parentNock = nock('https://api.github.com')
+        .get('/repos/' + mockOwner + '/' + mockRepo + '/pulls/comments/5')
+        .reply(200, { id: 5, body: 'orig', diff_hunk: '@@' });
+
+      await currentApp.app.receive({ name: 'pull_request_review_comment', id: 'test-event-id', payload });
+
+      expect(tokenNock.isDone()).toBe(true);
+      expect(parentNock.isDone()).toBe(true);
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        mockOwner,
+        mockRepo,
+        1,
+        expect.objectContaining({ id: 321 }),
+        expect.objectContaining({ id: 5 }),
+        ''
+      );
+    });
+
+    it('does not trigger on case mismatch', async () => {
+      const payload = JSON.parse(JSON.stringify(reviewCommentPayload));
+      payload.comment.body = '/Review please';
+
+      await currentApp.app.receive({ name: 'pull_request_review_comment', id: 'test-event-id', payload });
+
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+
+    it('parses additional text with multiple commands', async () => {
+      const payload = JSON.parse(JSON.stringify(reviewCommentPayload));
+      payload.comment.body = '/review please /review again';
+      payload.comment.id = 456;
+
+      const tokenNock = nock('https://api.github.com')
+        .post('/app/installations/2/access_tokens')
+        .reply(200, { token: 'test-token' });
+
+      const parentNock = nock('https://api.github.com')
+        .get('/repos/' + mockOwner + '/' + mockRepo + '/pulls/comments/5')
+        .reply(200, { id: 5, body: 'orig', diff_hunk: '@@' });
+
+      await currentApp.app.receive({ name: 'pull_request_review_comment', id: 'test-event-id', payload });
+
+      expect(tokenNock.isDone()).toBe(true);
+      expect(parentNock.isDone()).toBe(true);
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.any(Object),
+        mockOwner,
+        mockRepo,
+        1,
+        expect.objectContaining({ id: 456 }),
+        expect.objectContaining({ id: 5 }),
+        'please /review again'
+      );
+    });
+
+    it('handles errors when parent comment fetch fails', async () => {
+      const payload = JSON.parse(JSON.stringify(reviewCommentPayload));
+      payload.comment.body = '/review fail';
+
+      const tokenNock = nock('https://api.github.com')
+        .post('/app/installations/2/access_tokens')
+        .reply(200, { token: 'test-token' });
+
+      const parentNock = nock('https://api.github.com')
+        .get('/repos/' + mockOwner + '/' + mockRepo + '/pulls/comments/5')
+        .reply(500);
+
+      await currentApp.app.receive({ name: 'pull_request_review_comment', id: 'test-event-id', payload });
+
+      expect(tokenNock.isDone()).toBe(true);
+      expect(parentNock.isDone()).toBe(true);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processReviewCommentReply function', () => {
+    it('posts AI reply using parent comment id', async () => {
+      const mockOcto = { pulls: { createReplyForReviewComment: jest.fn().mockResolvedValue({}) } };
+      const comment = { id: 10, diff_hunk: '@@', path: 'file.js' };
+      const parent = { id: 5, body: 'hello', diff_hunk: '@@' };
+      await processReviewCommentReply(mockOcto, 'o', 'r', 1, comment, parent, 'hi');
+      expect(mockOcto.pulls.createReplyForReviewComment).toHaveBeenCalledWith(expect.objectContaining({
+        owner: 'o',
+        repo: 'r',
+        pull_number: 1,
+        comment_id: 5,
+        body: 'Mock AI response'
+      }));
+    });
+
+    it('sends error reply when posting fails', async () => {
+      const mockOcto = { pulls: { createReplyForReviewComment: jest.fn() } };
+      mockOcto.pulls.createReplyForReviewComment
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce({});
+      const comment = { id: 11, diff_hunk: '', path: '' };
+      const parent = { id: 6, body: '' };
+      await processReviewCommentReply(mockOcto, 'o', 'r', 2, comment, parent);
+      expect(mockOcto.pulls.createReplyForReviewComment).toHaveBeenCalledWith(expect.objectContaining({
+        comment_id: 6,
+        body: expect.stringContaining('Error processing review request')
+      }));
+    });
+
+    it('validates required parameters', async () => {
+      await expect(processReviewCommentReply(null, 'o', 'r', 1, {}, {})).rejects.toThrow('Missing required parameters');
     });
   });
 });

--- a/prompts/comment_reply.md
+++ b/prompts/comment_reply.md
@@ -1,0 +1,13 @@
+# Comment Follow-Up
+
+You are assisting in a pull request review thread. Provide a concise reply to the prior comment using the diff context when relevant.
+
+## Prior Comment
+{{comment}}
+
+## User Request
+{{request}}
+
+```diff
+{{snippet}}
+```


### PR DESCRIPTION
## Summary
- add `comment_reply.md` prompt for answering follow-up questions
- handle `pull_request_review_comment` events and reply via the AI
- implement `processReviewCommentReply` helper
- test the new review comment flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685fc97e0b44832c8f938b18e0ed245b