### PR TITLE
Improve LLM error logging and diff line handling

### DIFF
--- a/__tests__/analyzeWithAI.test.js
+++ b/__tests__/analyzeWithAI.test.js
@@ -1,0 +1,11 @@
+jest.mock('../llm', () => ({
+  createClient: () => ({
+    generate: jest.fn().mockRejectedValue(new Error('maximum token limit exceeded'))
+  })
+}));
+
+const { analyzeWithAI } = require('../index');
+
+test('reports token limit errors clearly', async () => {
+  await expect(analyzeWithAI('prompt', 'code', 'file.js')).rejects.toThrow('LLM token limit exceeded');
+});


### PR DESCRIPTION
## Summary
- clarify when LLM output exceeds `LLM_MAX_TOKENS`
- preserve original file line numbers when generating contextual diffs
- add regression tests for token limit handling and diff line numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a6a56d0630832ca8e7d0d33cc8558b