### PR TITLE
Handle empty text responses from Google GenAI

### DIFF
--- a/__tests__/llmGoogle.test.js
+++ b/__tests__/llmGoogle.test.js
@@ -1,0 +1,26 @@
+// Override Google GenAI mock to simulate missing text field
+jest.mock('@google/genai', () => {
+  return {
+    GoogleGenAI: jest.fn().mockImplementation(() => ({
+      models: {
+        generateContent: jest.fn().mockResolvedValue({
+          text: undefined,
+          candidates: [
+            { content: { parts: [{ text: 'Fallback ' }, { text: 'response' }] } }
+          ]
+        })
+      }
+    }))
+  };
+});
+
+const { createClient } = require('../llm');
+
+describe('Google client generate fallback', () => {
+  it('returns concatenated text when top-level text is missing', async () => {
+    process.env.LLM_PROVIDER = 'google';
+    const client = createClient();
+    const result = await client.generate('prompt');
+    expect(result).toBe('Fallback response');
+  });
+});

--- a/llm.js
+++ b/llm.js
@@ -73,8 +73,20 @@ function createClient() {
         topP: parseFloat(options.topP || process.env.LLM_TOP_P || '0.8'),
         topK: parseInt(options.topK || process.env.LLM_TOP_K || '40', 10)
       };
-      const result = await genAI.models.generateContent({ model, contents: [{ role: 'user', parts: [{ text: prompt }] }], config: generationConfig });
-      return result.text;
+      const result = await genAI.models.generateContent({
+        model,
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        config: generationConfig
+      });
+      const text =
+        result.text ||
+        result.candidates?.[0]?.content?.parts
+          ?.map((p) => p.text || '')
+          .join('');
+      if (!text) {
+        throw new Error('LLM returned empty response');
+      }
+      return text.trim();
     }
   };
 }


### PR DESCRIPTION
## Summary
- ensure Google GenAI responses without top-level text fall back to candidate parts
- validate this behavior with a dedicated unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a6b774a6bc832c93a8f305857624d4