### PR TITLE
Ensure PR diff retrieval and correct diff anchors

### DIFF
--- a/__tests__/linkLineNumbers.test.js
+++ b/__tests__/linkLineNumbers.test.js
@@ -1,0 +1,10 @@
+const { linkLineNumbers } = require('../index');
+
+describe('linkLineNumbers', () => {
+  it('creates links using md5 diff anchors', () => {
+    const text = 'Check line 10';
+    const refs = [{ file: 'README.md', lines: [10] }];
+    const result = linkLineNumbers(text, refs, 'owner', 'repo', 1);
+    expect(result).toBe('Check [line 10](https://github.com/owner/repo/pull/1/files#diff-04c6e90faac2675aa89e2176d2eec7d8R10)');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix PR summary `/what` command by falling back to an explicit diff request when the initial call returns no diff
- Use md5 hashing for diff anchors so line links in reviews point to the correct locations
- Add tests for diff-fetch fallback and diff-anchor link generation

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68a6f545fca0832cbb9dbb6a645cc86c