### PR TITLE
fix: trim indentation in review summary

### DIFF
--- a/__tests__/removeLeadingMarkdownHeading.test.js
+++ b/__tests__/removeLeadingMarkdownHeading.test.js
@@ -1,0 +1,9 @@
+const { removeLeadingMarkdownHeading } = require('..');
+
+describe('removeLeadingMarkdownHeading', () => {
+  it('removes leading heading and trims indentation', () => {
+    const input = '### Summary\n    - first item\n    - second item';
+    const expected = '- first item\n- second item';
+    expect(removeLeadingMarkdownHeading(input)).toBe(expected);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ function truncateToLines(text, maxLines) {
 
 function removeLeadingMarkdownHeading(text) {
   if (!text) return '';
-  return text.replace(/^\s*#{1,6}\s.*\n+/, '');
+  const noHeading = text.replace(/^\s*#{1,6}\s.*\n+/, '');
+  return noHeading.split('\n').map(line => line.trimStart()).join('\n');
 }
 
 function diffAnchor(file) {


### PR DESCRIPTION
## Summary
- ensure PR summary markdown renders correctly by stripping leading indentation after headings
- test markdown heading removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a701e09c4c832c94ea90da5775cc6b