### PR TITLE
feat: add /ask command for PR discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A GitHub App that uses generative AI models like Gemini, GPT, and Claude to prov
 - **Commands**:
   - `/review`: Generates a PR summary and performs a deep code review
   - `/what`: (optional) Only produce the summary of changes
+  - `/ask`: Ask questions about the pull request or a specific diff snippet, with answers considering the entire comment thread
 - **Inline Comment Replies**: Respond to review comment threads with `/review` to analyze a specific diff snippet
 - **Configurable Triggers**: Enable reactions to custom comment keywords or pull request labels
 - **Intelligent Analysis**:
@@ -78,6 +79,7 @@ To customise the review behaviour for a repository, add a file named `AI_REVIEW_
      - `TRIGGER_LABEL` (label name to trigger review, default `ai-review`)
      - `REVIEW_COMMENT_KEYWORD` (default `/review`)
      - `SUMMARY_COMMENT_KEYWORD` (default `/what`)
+     - `ASK_COMMENT_KEYWORD` (default `/ask`)
    - (Optional) Customize instructions with:
      - `ENABLE_REPO_INSTRUCTIONS` (`false` by default)
      - `INSTRUCTION_FILENAME` (file name containing instructions, default `AI_REVIEW_INSTRUCTIONS.md`)

--- a/prompts/ask_question.md
+++ b/prompts/ask_question.md
@@ -1,0 +1,7 @@
+# PR Question
+
+You are assisting a developer with questions about this pull request. Use the diff, commit history, and conversation context to answer.
+Reference relevant line numbers when helpful.
+
+## Question
+{{question}}

--- a/prompts/comment_reply.md
+++ b/prompts/comment_reply.md
@@ -1,9 +1,9 @@
 # Comment Follow-Up
 
-You are assisting in a pull request review thread. Provide a concise reply to the prior comment using the diff context when relevant.
+You are assisting in a pull request review thread. Use the conversation so far and diff context when relevant to craft a concise reply.
 
-## Prior Comment
-{{comment}}
+## Conversation
+{{thread}}
 
 ## User Request
 {{request}}


### PR DESCRIPTION
## Summary
- support `/ask` command so developers can query whole PRs or specific diffs
- document new command and env var
- add tests and prompt for question handling
- ensure answers consider full discussion threads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7917ef0c4832cb6d540b0481c5884