### PR TITLE
Preserve indentation in /ask markdown responses

### DIFF
--- a/__tests__/removeLeadingMarkdownHeading.test.js
+++ b/__tests__/removeLeadingMarkdownHeading.test.js
@@ -6,4 +6,10 @@ describe('removeLeadingMarkdownHeading', () => {
     const expected = '- first item\n- second item';
     expect(removeLeadingMarkdownHeading(input)).toBe(expected);
   });
+
+  it('preserves relative indentation', () => {
+    const input = '### Summary\n    - first item\n      - nested item\n        code block';
+    const expected = '- first item\n  - nested item\n    code block';
+    expect(removeLeadingMarkdownHeading(input)).toBe(expected);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -154,7 +154,12 @@ function truncateToLines(text, maxLines) {
 function removeLeadingMarkdownHeading(text) {
   if (!text) return '';
   const noHeading = text.replace(/^\s*#{1,6}\s.*\n+/, '');
-  return noHeading.split('\n').map(line => line.trimStart()).join('\n');
+  const lines = noHeading.split('\n');
+  const indents = lines
+    .filter(line => line.trim().length > 0)
+    .map(line => line.match(/^(\s*)/)[1].length);
+  const minIndent = indents.length ? Math.min(...indents) : 0;
+  return lines.map(line => line.slice(minIndent)).join('\n');
 }
 
 function diffAnchor(file) {


### PR DESCRIPTION
## Summary
- retain relative indentation after removing markdown headings
- add regression test for nested content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a7babefac8832c85f0dcbf88bdccf5