### PR TITLE
feat: log pr and timing for LLM calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ async function analyzeWithAI(prompt, codeSnippet, filePath, context = '', logCon
     const inputChars = message.length;
     const inputTokens = countTokens(message);
     structuredLog('INFO', 'LLM request started', { filePath, inputChars, inputTokens, repo: logContext.repo, pr: logContext.pr, model: llmClient?.model });
-    const resultText = await llmClient.generate(message, { });
+    const resultText = await llmClient.generate(message, { logContext });
     const durationMs = Date.now() - startTime;
     const outputChars = resultText ? resultText.length : 0;
     const outputTokens = countTokens(resultText);


### PR DESCRIPTION
## Summary
- include repo and PR info when LLM client makes requests and responses
- log response timing for each LLM call and forward context from analyzers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7ecd8e414832cb74188288e7ebe61