### PR TITLE
feat: throw error for missing env vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ const requiredVars = [
 
 for (const varName of requiredVars) {
   if (!process.env[varName]) {
-    structuredLog('ERROR', 'Missing required environment variable', { varName });
-    process.exit(1); // Exit if env vars are missing
+    const message = `Missing required environment variable: ${varName}`;
+    structuredLog('ERROR', message, { varName });
+    throw new Error(message);
   }
 }
 


### PR DESCRIPTION
## Summary
- throw descriptive error with missing env var name instead of exiting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a805fa9dc0832ca8ad8ef5a01dfe0c