### PR TITLE
feat: make review comment events optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ To customise the review behaviour for a repository, add a file named `AI_REVIEW_
      - `LOG_LEVEL` (`error`, `warn`, `info`, `debug`; default `info`)
    - (Optional) Control event triggers with:
      - `ENABLE_ISSUE_COMMENT_EVENT` (`true` by default)
+     - `ENABLE_REVIEW_COMMENT_EVENT` (`true` by default)
      - `ENABLE_LABEL_EVENT` (`false` by default)
      - `TRIGGER_LABEL` (label name to trigger review, default `ai-review`)
      - `REVIEW_COMMENT_KEYWORD` (default `/review`)

--- a/app.json
+++ b/app.json
@@ -107,6 +107,10 @@
       "description": "Respond to issue comments",
       "value": "true"
     },
+    "ENABLE_REVIEW_COMMENT_EVENT": {
+      "description": "Respond to review comments",
+      "value": "true"
+    },
     "ENABLE_LABEL_EVENT": {
       "description": "Respond to label events",
       "value": "false"

--- a/index.js
+++ b/index.js
@@ -883,6 +883,7 @@ async function handlePrAction(context, repository, prNumber, action, requestId) 
 function registerEventHandlers(probot, options = {}) {
   const {
     enableIssueComment = process.env.ENABLE_ISSUE_COMMENT_EVENT !== 'false',
+    enableReviewComment = process.env.ENABLE_REVIEW_COMMENT_EVENT !== 'false',
     enableLabel = process.env.ENABLE_LABEL_EVENT === 'true',
     reviewLabel = process.env.TRIGGER_LABEL || 'ai-review',
     reviewKeyword = process.env.REVIEW_COMMENT_KEYWORD || '/review',
@@ -924,6 +925,7 @@ function registerEventHandlers(probot, options = {}) {
     });
   }
 
+  if (enableReviewComment) {
     probot.on('pull_request_review_comment.created', async (context) => {
       const { comment, pull_request: pr, repository } = context.payload;
       const { body, in_reply_to_id } = comment;
@@ -954,6 +956,7 @@ function registerEventHandlers(probot, options = {}) {
       comment.__requestId = requestId;
       await module.exports.processReviewCommentReply(octokit, repoOwner, repoName, prNumber, comment, parent, userRequest, { requestId, repo: repository.full_name, totalTokens: 0 });
     });
+  }
 
   if (enableLabel) {
     probot.on('pull_request.labeled', async (context) => {


### PR DESCRIPTION
## Summary
- add `enableReviewComment` option defaulting to `ENABLE_REVIEW_COMMENT_EVENT`
- gate `pull_request_review_comment.created` handler behind the option
- document `ENABLE_REVIEW_COMMENT_EVENT` environment variable

## Testing
- `npm test --silent 2>&1 | grep -A4 'Test Suites'`


------
https://chatgpt.com/codex/tasks/task_b_68a805f5034c832c83018c3c28a11857