### PR TITLE
Handle directories in getFileContent

### DIFF
--- a/__tests__/getFileContent.test.js
+++ b/__tests__/getFileContent.test.js
@@ -1,0 +1,32 @@
+const nock = require('nock');
+const { Octokit } = require('@octokit/rest');
+let getFileContent;
+
+describe('getFileContent', () => {
+  const owner = 'test-owner';
+  const repo = 'test-repo';
+  const path = 'dir';
+  const ref = 'main';
+  const octokit = new Octokit();
+
+  beforeEach(() => {
+    nock.disableNetConnect();
+    jest.resetModules();
+    ({ getFileContent } = require('../index'));
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  it('returns placeholder for directory paths', async () => {
+    nock('https://api.github.com')
+      .get(`/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`)
+      .query(q => q.ref === ref)
+      .reply(200, [{ path: 'dir/file1.js' }]);
+
+    const result = await getFileContent(octokit, owner, repo, path, ref);
+    expect(result).toBe('[Directory content not supported]');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -165,6 +165,10 @@ async function getFileContent(octokit, owner, repo, path, ref, options = {}) {
   const { startLine, endLine, contextLines } = options;
   try {
     const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
+    if (Array.isArray(data)) {
+      structuredLog('WARN', 'Path does not resolve to a file', { path, ref });
+      return '[Directory content not supported]';
+    }
     const fileSize = typeof data === 'string' ? Buffer.byteLength(data) : data.size;
     if (fileSize > MAX_FILE_SIZE) {
       structuredLog('INFO', 'Truncating large file', { path, fileSize });


### PR DESCRIPTION
## Summary
- guard getFileContent against directory paths, logging a warning and returning a placeholder string
- test directory path handling in getFileContent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a805dcf328832c89b73fd8d0ee45a4