### PR TITLE
feat: add inline fix suggestions

### DIFF
--- a/__tests__/addSuggestionFormatting.test.js
+++ b/__tests__/addSuggestionFormatting.test.js
@@ -1,0 +1,14 @@
+const { addSuggestionFormatting } = require('../utils');
+
+describe('addSuggestionFormatting', () => {
+  it('converts diff blocks to suggestion blocks', () => {
+    const input = 'Issue\n```diff\n- old\n+ new\n```';
+    const expected = 'Issue\n```suggestion\n- old\n+ new\n```';
+    expect(addSuggestionFormatting(input)).toBe(expected);
+  });
+
+  it('leaves text without diff blocks unchanged', () => {
+    const input = 'No diff here';
+    expect(addSuggestionFormatting(input)).toBe(input);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const {
   diffAnchor,
   getSurroundingLines,
   shouldPostInlineComment,
+  addSuggestionFormatting,
 } = require('./utils');
 
 function loadPrompt(filename, values = {}) {
@@ -695,6 +696,7 @@ async function processReviewCommand(octokit, owner, repo, pr, files, dependencie
             for (const { lines, comment } of lineAnalyses) {
               const trimmed = comment.trim();
               if (!shouldPostInlineComment(trimmed)) continue;
+              const formatted = addSuggestionFormatting(trimmed);
               const key = trimmed.toLowerCase();
               if (!postedLineAnalyses.has(key)) {
                 postedLineAnalyses.add(key);
@@ -705,7 +707,7 @@ async function processReviewCommand(octokit, owner, repo, pr, files, dependencie
                     pull_number: pr.number,
                     commit_id: pr.head.sha,
                     path: info.filename,
-                    body: `${trimmed}\n\n_Lines: ${lines.join(', ')}_`,
+                    body: `${formatted}\n\n_Lines: ${lines.join(', ')}_`,
                     line: lines[0],
                     side: 'RIGHT'
                   });

--- a/prompts/line_review.md
+++ b/prompts/line_review.md
@@ -1,6 +1,10 @@
 # Line Review
 
-Using the manager instructions and any repository instructions below, provide feedback for the change around line {{line}} in {{fileName}}. Only consider the diffed lines shown. Use context from the snippet only when essential. If there are no actionable suggestions return an empty response.
+Using the manager instructions and any repository instructions below, provide feedback for the change around line {{line}} in {{fileName}}. Only consider the diffed lines shown. Use context from the snippet only when essential. If there are no actionable suggestions return an empty response. When highlighting an issue, also propose a fix where possible by including a GitHub suggestion block like:
+
+```suggestion
+<updated code>
+```
 
 ## Manager Instructions
 {{managerPlan}}

--- a/utils.js
+++ b/utils.js
@@ -86,6 +86,14 @@ function shouldPostInlineComment(comment) {
   return !skipPhrases.some(p => c.includes(p));
 }
 
+function addSuggestionFormatting(comment) {
+  if (!comment) return '';
+  return comment.replace(/```(?:diff|patch)\n([\s\S]*?)```/g, (_match, code) => {
+    const trimmed = code.trim();
+    return '```suggestion\n' + trimmed + '\n```';
+  });
+}
+
 module.exports = {
   countTokens,
   truncateToLines,
@@ -94,5 +102,6 @@ module.exports = {
   linkLineNumbers,
   getSurroundingLines,
   shouldPostInlineComment,
+   addSuggestionFormatting,
 };
 


### PR DESCRIPTION
## Summary
- prompt line reviewer to output GitHub-style suggestion blocks
- convert diff or patch blocks to suggestion blocks before posting comments
- test diff-to-suggestion conversion utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a81563fdf8832c89e27691463fb8ca