### PR TITLE
Add security review capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ A GitHub App that uses generative AI models like Gemini, GPT, and Claude to prov
 - **AI-Powered Code Review**: Analyze code using your choice of Gemini, GPT, or Claude models
 - **Commands**:
   - `/review`: Generates a PR summary and performs a deep code review
+  - `/review security`: Runs a security-focused analysis
   - `/what`: (optional) Only produce the summary of changes
   - `/ask`: Ask questions about the pull request or a specific diff snippet, with answers considering the entire comment thread
 - **Inline Comment Replies**: Respond to review comment threads with `/review` to analyze a specific diff snippet
 - **Configurable Triggers**: Enable reactions to custom comment keywords or pull request labels
+  - Adding the `security-review` label requests a security audit of the PR
 - **Intelligent Analysis**:
   - Identifies bugs and logical errors
   - Detects potential security vulnerabilities
@@ -26,6 +28,8 @@ A GitHub App that uses generative AI models like Gemini, GPT, and Claude to prov
 All prompts used for AI analysis live under the `prompts/` directory. The app loads these templates at runtime and fills in variables such as the file name or manager instructions before sending them to the configured model. Editing the text files allows you to tweak the review style without changing code.
 
 To customise the review behaviour for a repository, add a file named `AI_REVIEW_INSTRUCTIONS.md` to the repository root or within any folder. The contents of the closest instructions file are inserted into the review prompts for files in that directory. See `AI_REVIEW_INSTRUCTIONS_TEMPLATE.md` for an example template.
+
+To override the default security review prompt, add a `SECURITY_REVIEW_PROMPT.md` file to the repository root. This file replaces the built-in security template and supports placeholders like `{{repoLanguages}}`.
 
 ## Setup
 
@@ -84,6 +88,7 @@ To customise the review behaviour for a repository, add a file named `AI_REVIEW_
    - (Optional) Customize instructions with:
      - `ENABLE_REPO_INSTRUCTIONS` (`false` by default)
      - `INSTRUCTION_FILENAME` (file name containing instructions, default `AI_REVIEW_INSTRUCTIONS.md`)
+     - `SECURITY_PROMPT_FILENAME` (file name for security review prompt override, default `SECURITY_REVIEW_PROMPT.md`)
 
 ### Deploy to Cloud Run
 

--- a/app.json
+++ b/app.json
@@ -119,6 +119,10 @@
       "description": "Label to trigger review",
       "value": "ai-review"
     },
+    "SECURITY_REVIEW_LABEL": {
+      "description": "Label to trigger security review",
+      "value": "security-review"
+    },
     "REVIEW_COMMENT_KEYWORD": {
       "description": "Keyword to trigger review",
       "value": "/review"
@@ -134,6 +138,10 @@
     "INSTRUCTION_FILENAME": {
       "description": "Instruction file name",
       "value": "AI_REVIEW_INSTRUCTIONS.md"
+    },
+    "SECURITY_PROMPT_FILENAME": {
+      "description": "File name for security review prompt override",
+      "value": "SECURITY_REVIEW_PROMPT.md"
     }
   }
 }

--- a/prompts/security_review.md
+++ b/prompts/security_review.md
@@ -1,0 +1,84 @@
+You are a security-focused reviewer for pull requests.
+
+Context you receive
+
+- Repository languages: {{repoLanguages}}
+- PR diff, filenames, and any config files (Dockerfiles, K8s manifests, Cloud Run service configs, GitHub Actions, Terraform, Helm charts).
+- Team policy priorities: OWASP Top 10, CWE, supply chain, secrets, infrastructure misconfiguration.
+
+Your goal
+
+Identify real, high-confidence security risks introduced or exposed by this PR.
+When possible, propose a minimal patch (ready-to-apply) and explain why.
+If not confident, explicitly say “uncertain” and suggest what evidence would raise confidence.
+
+Review Scope (prioritized)
+
+- Direct vulnerabilities in code
+  - Injection: SQL/NoSQL/LDAP/OS commands; template injection; XSS; SSRF; path traversal; XXE.
+  - AuthN/AuthZ: missing/weak checks; IDOR; privilege escalation; CSRF.
+  - Crypto: weak algorithms/modes; static IV/salt; misuse of JWTs; insecure randomness; key management.
+  - Deserialization: Java (Serializable, Jackson polymorphic types), Python (pickle, yaml.load w/o SafeLoader), protobuf handling.
+  - Unsafe dynamic execution: eval, exec, reflection, subprocess with shell=true, Runtime.exec.
+  - Secrets: hardcoded tokens/keys/passwords; logging secrets.
+  - Input validation & output encoding: boundary checks, canonicalization, regex DoS.
+  - Concurrency/thread-safety with security impact (TOCTOU, shared mutable state).
+- Dependency & supply chain
+  - New dependencies or version bumps with known CVEs; unpinned versions; transitive risk.
+  - Build scripts/GitHub Actions: untrusted inputs, permissions (GITHUB_TOKEN scopes), artifact signing/verification.
+- Container & runtime
+  - Dockerfile: runs as root; no USER; writable root FS; missing HEALTHCHECK; unpinned base images; leaked build secrets.
+  - Kubernetes: runAsNonRoot, readOnlyRootFilesystem, drop capabilities (ALL), allowPrivilegeEscalation: false, seccompProfile: RuntimeDefault, no host networking/paths, resource requests/limits, probes, secret handling, least-privileged ServiceAccount/RBAC, imagePullPolicy, networkPolicies.
+  - Cloud Run: unauthenticated access, service account scopes, egress controls, CPU allocation, secrets from Secret Manager, ingress settings.
+- Observability & incident readiness
+  - PII logging; lack of audit logs for sensitive paths; correlation IDs; rate limiting/abuse controls.
+
+Evidence & Confidence
+
+Cite exact file paths and line ranges from the diff.
+For each finding, provide: root cause, exploit scenario, impact, and why confidence is high.
+If confidence is low, mark “uncertain” and list needed proof.
+
+Output Format (strict)
+
+Summary
+
+1–3 bullets summarizing overall risk posture of this PR.
+
+Findings
+
+For each finding:
+
+Title: short name (e.g., “SQL Injection via string concatenation”)
+Location: path/to/file:line-start–line-end
+Severity: critical | high | medium | low
+Confidence: high | medium | low
+Why it matters: 2–4 sentences (impact + exploit sketch).
+Proof: code excerpt (≤15 lines) or diff snippet.
+Fix:
+
+Patch (preferred): Provide a minimal unified diff or GitHub Suggested Change block.
+Rationale: 1–2 sentences.
+Follow-ups (optional): tests, configs, docs.
+References (optional): CWE/OWASP identifiers, library docs.
+
+Safe-by-Design Checks (pass/fail)
+
+Code: injection-safe, authz present, secrets absent, crypto OK, deserialization safe, logging hygiene.
+Dependencies: versions pinned, no known critical CVEs (note any).
+Container: non-root, read-only FS, healthcheck, multi-stage build, no embedded secrets.
+Kubernetes/Cloud Run: least privilege, network isolation, probes/limits, secret management, ingress as intended.
+
+Severity Rubric
+
+Critical: trivial remote exploit or secret exposure with high impact (RCE, auth bypass, database exfiltration).
+High: exploitable with moderate effort or widespread impact (SSRF to internal metadata, stored XSS, weak JWT signing).
+Medium: limited preconditions or mitigations exist (reflected XSS with encoding elsewhere, verbose error leakage).
+Low: unlikely or theoretical; hygiene issues (missing security headers where risk is low).
+
+Review Rules
+
+Prefer precision over recall: include only findings with actionable fixes.
+Provide one-liner rationale for any non-issues you explicitly considered.
+Avoid generic advice; tie every point to this PR’s code or config.
+If the PR reduces risk, call that out with “Security Improvements” and keep it in Summary.


### PR DESCRIPTION
## Summary
- support security-focused analysis via `/review security` and `security-review` label
- add security review prompt and configuration
- cover security triggers with new tests
- allow repositories to override the security review prompt via `SECURITY_REVIEW_PROMPT.md`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab8a2ad350832c8e8bf2be74bbaa8b